### PR TITLE
Add GitHub links to DESCRIPTION

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -11,3 +11,4 @@
 ^Meta$
 ^data-raw$
 ^\./tests/testthat/dataForTests/generate_weeklyTestData\.R$
+^bayesRecon\.Rproj$

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -52,3 +52,5 @@ Suggests:
     testthat (>= 3.0.0)
 Config/testthat/edition: 3
 VignetteBuilder: knitr
+URL: https://github.com/IDSIA/bayesRecon
+BugReports: https://github.com/IDSIA/bayesRecon/issues


### PR DESCRIPTION
This makes it a bit easier to find bayesRecon's GitHub home from CRAN